### PR TITLE
Add Queue Graphics

### DIFF
--- a/css/queue.css
+++ b/css/queue.css
@@ -1,0 +1,32 @@
+.tetris-block div {
+  width: 20px;
+  height: 20px;
+}
+
+.i-block div {
+  background-color: lightblue;
+}
+
+.j-block div {
+  background-color: blue;
+}
+
+.l-block div {
+  background-color: orange;
+}
+
+.o-block div {
+  background-color: yellow;
+}
+
+.s-block div {
+  background-color: lightgreen;
+}
+
+.t-block div {
+  background-color: purple;
+}
+
+.z-block div {
+  background-color: red;
+}

--- a/css/queue.css
+++ b/css/queue.css
@@ -1,6 +1,29 @@
+#queue {
+  width: 200px;
+}
+
+.position {
+  float: left;
+  margin-right: 10px;
+  vertical-align: center;
+}
+
+td {
+  vertical-align: top;
+}
+
 .tetris-block div {
   width: 20px;
   height: 20px;
+}
+
+.tetris-block {
+  margin: 10px;
+  border-spacing: 0px;
+}
+
+.tetris-block td {
+  padding: 0px;
 }
 
 .i-block div {

--- a/index.html
+++ b/index.html
@@ -4,9 +4,23 @@
     <script src="js/rend.js"></script>
     <script src="js/network.js"></script>
     <script src="js/client.js"></script>
+    <script src="js/queue.js"></script>
+
+    <script
+      src="https://code.jquery.com/jquery-3.4.1.min.js"
+      integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+      crossorigin="anonymous"></script>
+
     <meta charset="utf-8">
+
+    <link rel="stylesheet" href="css/queue.css">
 </head>
 
 <body onload="init();">
    <canvas id="board" width="400" height="400"></canvas>
+   
+   <div id='my-piece'>
+     <div id='my-piece-shape'></div>
+     <div>#<span id='my-piece-position'></span></div>
+   </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -17,10 +17,40 @@
 </head>
 
 <body onload="init();">
-   <canvas id="board" width="400" height="400"></canvas>
-   
-   <div id='my-piece'>
-     <div id='my-piece-shape'></div>
-     <div>#<span id='my-piece-position'></span></div>
-   </div>
+
+  <table>
+    <tr>
+      <td>
+        <canvas id="board" width="400" height="400"></canvas>
+      </td>
+      <td>
+        <div id='queue'>
+          <div id='block-queue'>
+            <p>Queue</p>
+            <div>
+              <div class='position'>#1</div>
+              <div class='shape'></div>
+
+            </div>
+            <div>
+              <div class='position'>#2</div>
+              <div class='shape'></div>
+
+            </div>
+            <div>
+              <div class='position'>#3</div>
+              <div class='shape'></div>
+            </div>
+          </div>
+
+          <div id='my-piece'>
+            <p>You</p>
+            <div class='position'>#</div>
+            <div class='shape'></div>
+          </div>
+        </div>
+      </td>
+    </tr>
+  </table>
+
 </body>

--- a/index.html
+++ b/index.html
@@ -17,14 +17,17 @@
 </head>
 
 <body onload="init();">
-
   <table>
     <tr>
+      <!-- canvas that the game is played on -->
       <td>
         <canvas id="board" width="400" height="400"></canvas>
       </td>
+
       <td>
         <div id='queue'>
+
+          <!-- stores the next three blocks that will appear in game -->
           <div id='block-queue'>
             <p>Queue</p>
             <div>
@@ -43,6 +46,7 @@
             </div>
           </div>
 
+          <!-- says when my piece will come up (eg. #1 or #21) -->
           <div id='my-piece'>
             <p>You</p>
             <div class='position'>#</div>

--- a/js/client.js
+++ b/js/client.js
@@ -63,7 +63,6 @@ function init() {
       initGrid();
       clearBoard();
       drawPieces();
-      initQueue();
       window.requestAnimationFrame(handleFrame);
     });
 }

--- a/js/client.js
+++ b/js/client.js
@@ -28,7 +28,7 @@ var keystate = [];
 var socket;
 var socketOpen = false;
 
-var game_state = new GameState([]);
+var game_state = new GameState([], [], []);
 // Actual Code
 
 /**
@@ -63,6 +63,7 @@ function init() {
       initGrid();
       clearBoard();
       drawPieces();
+      initQueue();
       window.requestAnimationFrame(handleFrame);
     });
 }

--- a/js/game_state.js
+++ b/js/game_state.js
@@ -58,12 +58,12 @@ class GameState {
     });
 
 
-    let piece_queue = [];
+    let piece_queue = [0, 4, 5, 6, 1];
     if (server_state.hasOwnProperty('piece_queue')) {
       piece_queue = [...server_state.piece_queue]; // clone an array ES6-style
     }
 
-    let player_queue = [];
+    let player_queue = [0, 1, 2, 3];
     if (server_state.hasOwnProperty('player_queue')) {
       player_queue = [...server_state.piece_queue];
     }

--- a/js/game_state.js
+++ b/js/game_state.js
@@ -36,10 +36,14 @@ class PieceState {
   }
 }
 
+
+
 // TODO: implement this within our code
 class GameState {
-  constructor(piece_states) {
+  constructor(piece_states, piece_queue, player_queue) {
     this.piece_states = piece_states;
+    this.piece_queue = piece_queue;
+    this.player_queue = player_queue;
   }
 
   static fromJson(json) {
@@ -53,6 +57,17 @@ class GameState {
         x.player_id);
     });
 
-    return new GameState(piece_states);
+
+    let piece_queue = [];
+    if (server_state.hasOwnProperty('piece_queue')) {
+      piece_queue = [...server_state.piece_queue]; // clone an array ES6-style
+    }
+
+    let player_queue = [];
+    if (server_state.hasOwnProperty('player_queue')) {
+      player_queue = [...server_state.piece_queue];
+    }
+
+    return new GameState(piece_states, piece_queue, player_queue);
   }
 }

--- a/js/queue.js
+++ b/js/queue.js
@@ -90,8 +90,6 @@ function getPieceHTML(shape) {
   }
 }
 
-// how many pieces can be playing at one time
-const MAX_ACTIVE_PIECES = 1;
 
 // returns -1 if player isn't in queue, else returns 0 or greater indicating
 // position in queue
@@ -116,10 +114,10 @@ function getMyPieceShape() {
   return -1;
 }
 
+// draws the my-piece section which shows when my own
+// piece will be put into the game
 function drawMyPiece() {
   let queue_position = getMyQueuePosition();
-
-  console.log(queue_position);
 
   // if my piece is in the queue
   if (queue_position != -1) {
@@ -128,6 +126,8 @@ function drawMyPiece() {
   }
 }
 
+// draws the block queue which shows what the next three
+// blocks will be
 function drawBlockQueue() {
   let children = $("#block-queue").children();
 
@@ -139,10 +139,4 @@ function drawBlockQueue() {
 function updateQueue() {
   drawMyPiece();
   drawBlockQueue();
-
-  console.log("update queue");
-}
-
-function initQueue() {
-
 }

--- a/js/queue.js
+++ b/js/queue.js
@@ -1,0 +1,137 @@
+let IBLOCK_HTML = `<table class='tetris-block i-block'>
+   <tr>
+     <td><div></td>
+     <th><div></th>
+      <th><div></th>
+      <th><div></th>
+   </tr>
+</table>`;
+
+let JBLOCK_HTML = `<table class='tetris-block j-block'>
+   <tr>
+     <th><div></th>
+   </tr>
+   <tr>
+     <th><div></th>
+     <td><div></td>
+     <td><div></td>
+   </tr>
+</table>`;
+
+let LBLOCK_HTML = `<table class='tetris-block l-block'>
+   <tr>
+     <th></th>
+     <th></th>
+     <th><div></th>
+   </tr>
+   <tr>
+     <th><div></th>
+     <td><div></td>
+     <td><div></td>
+   </tr>
+</table>`;
+
+let OBLOCK_HTML = `<table class='tetris-block o-block'>
+   <tr>
+     <th><div></th>
+     <td><div></td>
+   </tr>
+   <tr>
+     <th><div></th>
+     <td><div></td>
+   </tr>
+</table>`;
+
+let SBLOCK_HTML = `<table class='tetris-block s-block'>
+   <tr>
+     <th></th>
+     <th><div></th>
+     <td><div></td>
+   </tr>
+   <tr>
+     <th><div></th>
+     <td><div></td>
+   </tr>
+</table>`;
+
+let TBLOCK_HTML = `<table class='tetris-block t-block'>
+   <tr>
+     <th></th>
+     <th><div></th>
+   </tr>
+   <tr>
+     <th><div></th>
+     <td><div></td>
+     <td><div></td>
+   </tr>
+</table>`;
+
+let ZBLOCK_HTML = `<table class='tetris-block z-block'>
+   <tr>
+     <th><div></th>
+     <th><div></th>
+   </tr>
+   <tr>
+     <th></th>
+     <td><div></td>
+     <td><div></td>
+   </tr>
+</table>`;
+
+function getPieceHTML(shape) {
+  switch(shape) {
+    case 0: return ZBLOCK_HTML;
+    case 1: return SBLOCK_HTML;
+    case 2: return JBLOCK_HTML;
+    case 3: return LBLOCK_HTML;
+    case 4: return TBLOCK_HTML;
+    case 5: return IBLOCK_HTML;
+    case 6: return OBLOCK_HTML;
+  }
+}
+
+const MAX_ACTIVE_PIECES = 1;
+
+// show the first three pieces
+const PIECE_QUEUE_LENGTH = 3;
+
+// returns -1 if player isn't in queue, else returns 0 or greater indicating
+// position in queue
+function getMyQueuePosition() {
+  for (let i = 0; i < game_state.player_queue.length; i+=1) {
+    if (game_state.player_queue[i] == my_player_id && i >= MAX_ACTIVE_PIECES) {
+      return i - MAX_ACTIVE_PIECES;
+    }
+  }
+
+  return -1;
+}
+
+// TODO: fill this in.
+function getMyPieceShape() {
+  return 2;
+}
+
+function drawMyPiece() {
+  let queue_position = getMyQueuePosition();
+  let my_piece_shape = getMyPieceShape();
+
+  if (queue_position > PIECE_QUEUE_LENGTH) {
+    $("#my-piece-shape").html(getPieceHTML(my_piece_shape))
+    $("#my-piece-position").html(queue_position);
+    $("#my-piece").removeClass("hidden");
+  }
+  else {
+    $("#my-piece").addClass("hidden");
+  }
+}
+
+function updateQueue() {
+
+
+  console.log("update queue");
+}
+
+function initQueue() {
+
+}

--- a/js/queue.js
+++ b/js/queue.js
@@ -1,18 +1,18 @@
 let IBLOCK_HTML = `<table class='tetris-block i-block'>
-   <tr>
-     <td><div></td>
-     <th><div></th>
-      <th><div></th>
-      <th><div></th>
-   </tr>
+  <tr>
+    <td><div></td>
+    <td><div></td>
+    <td><div></td>
+    <td><div></td>
+  </tr>
 </table>`;
 
 let JBLOCK_HTML = `<table class='tetris-block j-block'>
    <tr>
-     <th><div></th>
+     <td><div></td>
    </tr>
    <tr>
-     <th><div></th>
+     <td><div></td>
      <td><div></td>
      <td><div></td>
    </tr>
@@ -20,12 +20,12 @@ let JBLOCK_HTML = `<table class='tetris-block j-block'>
 
 let LBLOCK_HTML = `<table class='tetris-block l-block'>
    <tr>
-     <th></th>
-     <th></th>
-     <th><div></th>
+     <td></td>
+     <td></td>
+     <td><div></td>
    </tr>
    <tr>
-     <th><div></th>
+     <td><div></td>
      <td><div></td>
      <td><div></td>
    </tr>
@@ -33,34 +33,34 @@ let LBLOCK_HTML = `<table class='tetris-block l-block'>
 
 let OBLOCK_HTML = `<table class='tetris-block o-block'>
    <tr>
-     <th><div></th>
+     <td><div></td>
      <td><div></td>
    </tr>
    <tr>
-     <th><div></th>
+     <td><div></td>
      <td><div></td>
    </tr>
 </table>`;
 
 let SBLOCK_HTML = `<table class='tetris-block s-block'>
    <tr>
-     <th></th>
-     <th><div></th>
+     <td></td>
+     <td><div></td>
      <td><div></td>
    </tr>
    <tr>
-     <th><div></th>
+     <td><div></td>
      <td><div></td>
    </tr>
 </table>`;
 
 let TBLOCK_HTML = `<table class='tetris-block t-block'>
    <tr>
-     <th></th>
-     <th><div></th>
+     <td></td>
+     <td><div></td>
    </tr>
    <tr>
-     <th><div></th>
+     <td><div></td>
      <td><div></td>
      <td><div></td>
    </tr>
@@ -68,11 +68,11 @@ let TBLOCK_HTML = `<table class='tetris-block t-block'>
 
 let ZBLOCK_HTML = `<table class='tetris-block z-block'>
    <tr>
-     <th><div></th>
-     <th><div></th>
+     <td><div></td>
+     <td><div></td>
    </tr>
    <tr>
-     <th></th>
+     <td></td>
      <td><div></td>
      <td><div></td>
    </tr>
@@ -90,17 +90,15 @@ function getPieceHTML(shape) {
   }
 }
 
+// how many pieces can be playing at one time
 const MAX_ACTIVE_PIECES = 1;
-
-// show the first three pieces
-const PIECE_QUEUE_LENGTH = 3;
 
 // returns -1 if player isn't in queue, else returns 0 or greater indicating
 // position in queue
 function getMyQueuePosition() {
   for (let i = 0; i < game_state.player_queue.length; i+=1) {
-    if (game_state.player_queue[i] == my_player_id && i >= MAX_ACTIVE_PIECES) {
-      return i - MAX_ACTIVE_PIECES;
+    if (game_state.player_queue[i] == my_player_id) {
+      return i;
     }
   }
 
@@ -109,25 +107,38 @@ function getMyQueuePosition() {
 
 // TODO: fill this in.
 function getMyPieceShape() {
-  return 2;
+  for (let i = 0; i < game_state.player_queue.length; i+=1) {
+    if (game_state.player_queue[i] == my_player_id) {
+      return i;
+    }
+  }
+
+  return -1;
 }
 
 function drawMyPiece() {
   let queue_position = getMyQueuePosition();
-  let my_piece_shape = getMyPieceShape();
 
-  if (queue_position > PIECE_QUEUE_LENGTH) {
-    $("#my-piece-shape").html(getPieceHTML(my_piece_shape))
-    $("#my-piece-position").html(queue_position);
-    $("#my-piece").removeClass("hidden");
+  console.log(queue_position);
+
+  // if my piece is in the queue
+  if (queue_position != -1) {
+    $("#my-piece .shape").html(getPieceHTML(getMyPieceShape()));
+    $("#my-piece .position").html("#" + queue_position);
   }
-  else {
-    $("#my-piece").addClass("hidden");
+}
+
+function drawBlockQueue() {
+  let children = $("#block-queue").children();
+
+  for (let i = 0; i < children.length; i++) {
+    $(children[i]).find(".shape").html(getPieceHTML(game_state.piece_queue[i]));
   }
 }
 
 function updateQueue() {
-
+  drawMyPiece();
+  drawBlockQueue();
 
   console.log("update queue");
 }

--- a/js/rend.js
+++ b/js/rend.js
@@ -51,4 +51,5 @@ function initGrid() {
 function draw_frame() {
     clearBoard();
     drawPieces();
+    updateQueue();
 }


### PR DESCRIPTION
The new queue should work automatically when new data is sent in the following format:

```
{
   piece_states: ... same as before ...
   piece_queue: [1, 3, 6, 2, 4],
   player_queue: [3, 2, 1],
}
```

Here, `player_queue` does NOT contain the players that are currently in the game.

Here is an image of the new queue. Its very simple for now, but I want to test the logic before polishing more.

<img src="https://user-images.githubusercontent.com/2799308/68275292-133deb80-0020-11ea-9605-485d18ec9f5c.png" height="400" />


