### PR TITLE
Shift Pieces

### DIFF
--- a/js/queue.js
+++ b/js/queue.js
@@ -122,7 +122,9 @@ function drawMyPiece() {
   // if my piece is in the queue
   if (queue_position != -1) {
     $("#my-piece .shape").html(getPieceHTML(getMyPieceShape()));
-    $("#my-piece .position").html("#" + queue_position);
+
+    // add 1 to convert from zero-indexed to 1-indexed
+    $("#my-piece .position").html("#" + (queue_position + 1));
   }
 }
 

--- a/rust/src/tetris/mod.rs
+++ b/rust/src/tetris/mod.rs
@@ -45,7 +45,7 @@ const I_BLOCK_Y_KICKS : [ [i8 ; 8] ; 4] = [
 
 
 const ROT_LIMIT : u8 = 4;
-const BOARD_WIDTH : i8 = 20;
+pub const BOARD_WIDTH : i8 = 20;
 
 pub fn update_state(players : &mut Slab<PieceState>, player_input : &KeyState) {
     let new_state = apply_input(player_input, players);
@@ -233,4 +233,3 @@ fn wallkick(mut new_state : &mut PieceState, clockwise : bool,
     // TODO: Prevent from re-checking collision afterwards
     return *new_state;
 }
-


### PR DESCRIPTION
Pieces are shifted down at a rate of 1 block / second. When the piece pivot moves off of the game board, the `remove_from_play(piece_id : usize)` method is called with the `piece_id` to remove. 