### PR TITLE
Blocks Accumulate on Bottom of Screen

### DIFF
--- a/js/game_state.js
+++ b/js/game_state.js
@@ -36,14 +36,23 @@ class PieceState {
   }
 }
 
+class BlockState {
+  constructor(x, y, original_shape) {
+    this.original_shape = original_shape;
+    this.x = x;
+    this.y = y;
+  }
+}
+
 
 
 // TODO: implement this within our code
 class GameState {
-  constructor(piece_states, piece_queue, player_queue) {
+  constructor(piece_states, piece_queue, player_queue, fallen_blocks) {
     this.piece_states = piece_states;
     this.piece_queue = piece_queue;
     this.player_queue = player_queue;
+    this.fallen_blocks = fallen_blocks;
   }
 
   static fromJson(json) {
@@ -57,6 +66,12 @@ class GameState {
         x.player_id);
     });
 
+    let fallen_blocks = server_state.fallen_blocks.map((fallen_block) => {
+      return new BlockState(
+        fallen_block.position.x,
+        fallen_block.position.y,
+        fallen_block.original_shape);
+    });
 
     let piece_queue = [0, 4, 5, 6, 1];
     if (server_state.hasOwnProperty('piece_queue')) {
@@ -68,6 +83,6 @@ class GameState {
       player_queue = [...server_state.piece_queue];
     }
 
-    return new GameState(piece_states, piece_queue, player_queue);
+    return new GameState(piece_states, piece_queue, player_queue, fallen_blocks);
   }
 }

--- a/js/rend.js
+++ b/js/rend.js
@@ -9,28 +9,49 @@ function clearBoard() {
     ctx.stroke();
 }
 
+function drawBlock(x, y, color, glow) {
+  ctx.fillStyle = color;
+  if (glow) {
+    ctx.shadowColor = '#ffffffee';
+    ctx.shadowBlur = 40;
+  }
+  else {
+    ctx.shadowColor = '#00000000';
+    ctx.shadowBlur = 0;
+  }
+
+  // Draw the blocks in the shape
+  let posX = canvasWidth * x / boardWidth;
+  let posY = canvasHeight * y / boardWidth;
+  ctx.fillRect(posX, posY, blockWidth, blockHeight);
+}
+
 function drawPieces() {
     game_state.piece_states.forEach((piece_state) => {
+
       let [x, y, color, width, rot_shape] = piece_state.getPiece().getRenderInfo();
-      ctx.fillStyle = color;
-      if (piece_state.player_id == my_player_id) {
-        ctx.shadowColor = '#ffffffee';
-        ctx.shadowBlur = 40;
-      }
-      else {
-        ctx.shadowColor = '#00000000';
-        ctx.shadowBlur = 0;
-      }
+
       // Draw the blocks in the shape
       for (i in rot_shape) {
           if (rot_shape[i] == 1) {
-              let posX = canvasWidth * (piece_state.pivot.x + i % width) / boardWidth;
-              let posY = canvasHeight * (piece_state.pivot.y + Math.floor(i / width) )
-                              / boardWidth;
-              ctx.fillRect(posX, posY, blockWidth, blockHeight);
+              let x = (piece_state.pivot.x + i % width);
+              let y = (piece_state.pivot.y + Math.floor(i / width));
+              let glow = piece_state.player_id == my_player_id;
+
+              drawBlock(x, y, color, glow);
           }
       }
     });
+}
+
+function drawFallenBlocks() {
+  game_state.fallen_blocks.forEach((fallen_block) => {
+    // TODO: this is a bit hacky
+    let color = shapes[fallen_block.original_shape].color;
+
+    // no glow on fallen blocks
+    drawBlock(fallen_block.x, fallen_block.y, color, fallen_block.false);
+  });
 }
 
 function initGrid() {
@@ -51,5 +72,6 @@ function initGrid() {
 function draw_frame() {
     clearBoard();
     drawPieces();
+    drawFallenBlocks();
     updateQueue();
 }

--- a/rust/src/piece_state/mod.rs
+++ b/rust/src/piece_state/mod.rs
@@ -13,3 +13,9 @@ pub struct PieceState {
     pub rotation: u8,
     pub player_id: usize
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct BlockState {
+    pub original_shape: u8, // this is so we can use existing methods to determine color
+    pub position: Pivot,
+}

--- a/rust/src/piece_state/mod.rs
+++ b/rust/src/piece_state/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Pivot {
     pub x: i8,
     pub y: i8,

--- a/rust/src/tetris/mod.rs
+++ b/rust/src/tetris/mod.rs
@@ -104,7 +104,7 @@ fn apply_input(player_input : &KeyState,
  *  original.
  *
 **/
-fn read_block(piece : &[bool], x : i8, y : i8, rot : u8) -> bool {
+pub fn read_block(piece : &[bool], x : i8, y : i8, rot : u8) -> bool {
     let length : i8 = piece.len().try_into().unwrap();
     // Matrix width, 3 if there are 9 elements, 4 if there are 16
     let width = if length == 9 {3} else {4};
@@ -138,7 +138,7 @@ fn read_block(piece : &[bool], x : i8, y : i8, rot : u8) -> bool {
     }
 }
 
-fn get_shape(shape_num : u8) -> &'static [bool] {
+pub fn get_shape(shape_num : u8) -> &'static [bool] {
     match shape_num {
         0 => &PIECE_Z,
         1 => &PIECE_S,
@@ -184,19 +184,13 @@ pub fn bottom_collision(piece_state : &PieceState, fallen_blocks : &Vec<BlockSta
     // let this_shape = get_shape(piece.shape);
     // let width = if this_shape.len() == 9 {3} else {4};
     // let this_origin = piece.pivot;
-    //
-    // for y in 0..width {
-    //     for x in 0..width {
-    //         let abs_x = x + this_origin.x;
-    //         let abs_y = y + this_origin.y;
-    //         if read_block(this_shape, x, y, piece.rotation) &&
-    //                 (abs_x >= BOARD_WIDTH || abs_x < 0 || abs_y < 0) {
-    //             return true;
-    //         }
-    //     }
-    // }
 
-    return false;
+    let bottom_screen_collision = match screen_collision(piece_state) {
+        CollisionType::Floor => true,
+        _ => false,
+    };
+
+    return bottom_screen_collision;
 }
 
 

--- a/rust/src/tetris/mod.rs
+++ b/rust/src/tetris/mod.rs
@@ -203,7 +203,7 @@ pub fn fallen_blocks_collision(piece : &PieceState, fallen_blocks : &HashMap<Piv
             if read_block(this_shape, x, y, piece.rotation) {
                 // if the position of one of the blocks that makes up piece overlaps
                 // with the location of a block in fallen_blocks, we have a collision
-                
+
                 if fallen_blocks.contains_key(&Pivot{x: abs_x, y: abs_y}) {
                     return true;
                 }
@@ -213,7 +213,6 @@ pub fn fallen_blocks_collision(piece : &PieceState, fallen_blocks : &HashMap<Piv
 
     return false;
 }
-
 
 
 fn collision(piece : &PieceState, players_slab : &mut Slab<PieceState>)

--- a/rust/src/tetris/mod.rs
+++ b/rust/src/tetris/mod.rs
@@ -1,6 +1,8 @@
 extern crate slab;
+use std::collections::HashMap;
 
-use crate::piece_state::{PieceState, BlockState};
+use crate::piece_state::{PieceState, Pivot};
+
 use crate::input::{KeyState};
 
 use slab::Slab;
@@ -179,18 +181,37 @@ pub fn screen_collision(piece : &PieceState) -> CollisionType {
     return CollisionType::None;
 }
 
-pub fn bottom_collision(piece_state : &PieceState, fallen_blocks : &Vec<BlockState>) -> bool {
-    // Check if in bounds
-    // let this_shape = get_shape(piece.shape);
-    // let width = if this_shape.len() == 9 {3} else {4};
-    // let this_origin = piece.pivot;
-
-    let bottom_screen_collision = match screen_collision(piece_state) {
+pub fn fallen_blocks_collision(piece : &PieceState, fallen_blocks : &HashMap<Pivot, u8>) -> bool {
+    // Check if we collide with the bottom of the screen
+    let bottom_screen_collision = match screen_collision(piece) {
         CollisionType::Floor => true,
         _ => false,
     };
+    if bottom_screen_collision { return true; }
 
-    return bottom_screen_collision;
+    // check if we collide with any of the bottom blocks
+
+    let this_shape = get_shape(piece.shape);
+    let width = if this_shape.len() == 9 {3} else {4};
+    let this_origin = piece.pivot;
+
+    for y in 0..width {
+        for x in 0..width {
+            let abs_x = x + this_origin.x;
+            let abs_y = y + this_origin.y;
+
+            if read_block(this_shape, x, y, piece.rotation) {
+                // if the position of one of the blocks that makes up piece overlaps
+                // with the location of a block in fallen_blocks, we have a collision
+                
+                if fallen_blocks.contains_key(&Pivot{x: abs_x, y: abs_y}) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
 }
 
 


### PR DESCRIPTION
Now the server sends the following field in the JSON update:

```
fallen_blocks: [{
   pivot: {
      x: 1,
      y: 19,
   },
   original_shape: 2
}, ...]
```

Original shape identifies what shape this block back when it was alive. This is used to determine its color. This is cleaner than sending color because it allows us to keep color code entirely on the client.

This needs to be integrated into Matt's queue code to work properly. Right now, active pieces stay on the bottom of the screen even after the `remove_from_play` method is called, leading to some undesirable behavior.

Here is a screenshot of the client:

![image](https://user-images.githubusercontent.com/2799308/68418918-133c0980-014e-11ea-87e0-c143d63c3699.png)
