### PR TITLE
Timeout Disconnect Works

### DIFF
--- a/js/network.js
+++ b/js/network.js
@@ -14,7 +14,12 @@ function getMyPiece() {
 @connectionCallback: function called game_state has been receive from server
 */
 function initSocket(connectionCallback) {
-    socket = new WebSocket("ws://127.0.0.1:3012");
+    let hostname = location.hostname == "" ? "localhost" : location.hostname;
+
+    let websocketAddress = `ws://${hostname}:3012`;
+    console.log(`Connecting to WebSocket at: ${websocketAddress}`);
+
+    socket = new WebSocket(websocketAddress);
     let made_callback = false;
 
     socket.onopen = function(e) {


### PR DESCRIPTION
This is not an elegant solution because I haven't found a way to terminate a connection. However, it does work reasonably well for the time being. The only thing that worries me is if a client disconnects and then somehow reconnects using the same connection, we may have serious server-side problems. When I have found a way to terminate a connection, we will no longer have this problem.  

I have posted in two places about termination and expect a response soon:

1. https://github.com/housleyjk/ws-rs/issues/298
2. https://stackoverflow.com/questions/58896106/rust-ws-library-terminate-websocket-connection

